### PR TITLE
[fix] slug/name in repository

### DIFF
--- a/src/shared/src/functions.rs
+++ b/src/shared/src/functions.rs
@@ -88,10 +88,10 @@ pub async fn import_repositories(
             .to_lowercase();
 
         let repo_query = repo.insert_respository_query();
-
+        repo_data.full_name;
         let repo_row = sqlx::query(repo_query)
-            .bind(&repo.label)
-            .bind(&repo_info.name)
+            .bind(&repo_info.name) // slug
+            .bind(&repo.label) // name
             .bind(format!(
                 "https://github.com/{}/{}",
                 &repo_info.owner, &repo_info.name


### PR DESCRIPTION
- Fix `slug`/`name` in repository

PS: 
- this requires updating the current values in the database
- we should use `owner+name` to avoid duplicated values, for example, `extension` should be `polkadot-js/extension`
